### PR TITLE
fixing jekyll warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,8 @@ defmodule Guides.MixProject do
         extra_section: "GUIDES",
         filter_prefix: "none",
         extras: extras(),
-        groups_for_extras: groups_for_extras()
+        groups_for_extras: groups_for_extras(),
+        javascript_config_path: nil
       ]
     ]
   end


### PR DESCRIPTION
Running locally Jekyll causes following error:
`ERROR `/docs_config.js' not found.`

* https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-additional-javascript-config
* looks like it is not crucial to have this file set