### PR TITLE
Fix channel name mismatches

### DIFF
--- a/guides/create_an_app/2-channels.md
+++ b/guides/create_an_app/2-channels.md
@@ -128,7 +128,7 @@ channel.join()
   .receive("error", resp => { console.log("Unable to join", resp) })
 ```
 
-`socket.channel("random:lobby", {})` sends the join request to the server, and the server sends the message back to the client. Here, we listen for a keypress event on the message text field. Whenever the user enters a message, it’s pushed on the channel and the text field is cleared. When there’s an incoming message on the channel, it’s appended to the **div** we previously created and scrolled to the bottom.
+`socket.channel("general:lobby", {})` sends the join request to the server, and the server sends the message back to the client. Here, we listen for a keypress event on the message text field. Whenever the user enters a message, it’s pushed on the channel and the text field is cleared. When there’s an incoming message on the channel, it’s appended to the **div** we previously created and scrolled to the bottom.
 
 Next we will want to create the container for our messages. Open `lib/workshops_app_web/templates/page/index.html.eex`, and replace its contents with:
 

--- a/guides/create_an_app/4-query.md
+++ b/guides/create_an_app/4-query.md
@@ -11,7 +11,7 @@ We are going to send a message contaning our `self` *PID(Process Identifier)* as
 Add this line to function inside `lib/workshops_app_web/channels/general_channel.ex`
 
 ```elixir
-  def join("random:lobby", payload, socket) do
+  def join("general:lobby", payload, socket) do
     if authorized?(payload) do
       send(self(), :after_join) # <-- Add this line
       {:ok, socket}


### PR DESCRIPTION
I believe the name "random:lobby" was used in the previous version of the guides and was overlooked in a few places.