### PR TITLE
Propose an alternative HTML snippet

### DIFF
--- a/guides/create_an_app/2-channels.md
+++ b/guides/create_an_app/2-channels.md
@@ -133,15 +133,17 @@ channel.join()
 Next we will want to create the container for our messages. Open `lib/workshops_app_web/templates/page/index.html.eex`, and replace its contents with:
 
 ```html
-<div id='message-list' class='row'>
+<div class='row'>
+  <div id='message-list'>
+  </div>
 </div>
 
-<div class='row form-group'>
-  <div class='col-md-3'>
-    <input type='text' id='name' class='form-control' placeholder='Name' />
+<div class='row'>
+  <div>
+    <input type='text' id='name' placeholder='Name' />
   </div>
-  <div class='col-md-9'>
-    <input type='text' id='message' class='form-control' placeholder='Message' />
+  <div>
+    <input type='text' id='message' placeholder='Message' />
   </div>
 </div>
 ```
@@ -151,6 +153,7 @@ What we have done here is create an empty **div** that will list all the chat me
 ```css
 #message-list {
   border: 1px solid #777;
+  width: 100%;
   height: 400px;
   padding: 10px;
   overflow: scroll;


### PR DESCRIPTION
Classes `form-group`, `form-control`, `col-md-n`, come from Bootstrap, which we don't add to the project.

Class `row` comes from phoenix.css, and it has a `display: flex` style. The code handling inserting new messages into the DOM inserts them as inline text with `<br>`, and the `<br>` doesn't behave as expected when directly inside a `display: flex` container. That causes all of the messages to appear on the same line.

I assume that if those changes are approved, I should also to update the example code in https://github.com/Taste-Elixir/workshops-app, correct?